### PR TITLE
fix(sikkari-oauth-oidc/07): メッセージ記法を修正

### DIFF
--- a/books/sikkari-oauth-oidc/07-access-token-validation.md
+++ b/books/sikkari-oauth-oidc/07-access-token-validation.md
@@ -37,7 +37,7 @@ Authorization: Bearer ACCESS_TOKEN_VALUE
 リソースサーバは、この `Authorization` ヘッダーからアクセストークンを抽出し、
 検証手順に進みます。
 
-:::
+:::message
 
 `Authorization` ヘッダ以外の送付方法も存在しますが、
 基本的には `Authorization` ヘッダを使用することが推奨されます。


### PR DESCRIPTION
初めまして。
[Kawaiiパワーで完全に理解！しっかりやり切るOAuthとOIDC入門 (執筆中)](https://zenn.dev/calloc134/books/sikkari-oauth-oidc) を楽しく拝読しております！

さて、同書の[アクセストークンの検証手順](https://zenn.dev/calloc134/books/sikkari-oauth-oidc/viewer/07-access-token-validation)チャプターのMarkdownのメッセージ記法修正のためPRを作成させていただきました。

間違っていましたらすみません🙏

## before

[アクセストークンの検証手順｜Kawaiiパワーで完全に理解！しっかりやり切るOAuthとOIDC入門 (執筆中)](https://zenn.dev/calloc134/books/sikkari-oauth-oidc/viewer/07-access-token-validation)

<img width="560" height="204" alt="image" src="https://github.com/user-attachments/assets/a11373e1-171f-40ab-82da-36f816c14579" />

## after

<http://localhost:8000/books/sikkari-oauth-oidc/07-access-token-validation%252Emd>（zenn cliによるプレビュー）

<img width="738" height="134" alt="image" src="https://github.com/user-attachments/assets/63d18648-7ef4-46d2-b6ce-8babed12ae04" />
